### PR TITLE
Send token instead of credentials to GitHub on GET

### DIFF
--- a/utils/github.js
+++ b/utils/github.js
@@ -1,14 +1,12 @@
 const axios = require('axios');
 require('dotenv').config();
+const auth = 'token ' + process.env.GITHUB_TOKEN;
 
 // Return Repo Details
 function getRepoDetails(githubUser, repoName) {
     return new Promise((resolve, reject) => {
         axios.get(`https://api.github.com/repos/${githubUser}/${repoName}`, {
-            auth: {
-                username: process.env.GITHUB_USER,
-                password: process.env.GITHUB_PASS
-            }
+            Authorization: auth
         })
             .then(function (response) {
                 resolve(response.data);
@@ -23,10 +21,7 @@ function getRepoDetails(githubUser, repoName) {
 function getRepoIssues(githubUser, repoName) {
     return new Promise((resolve, reject) => {
         axios.get(`https://api.github.com/repos/${githubUser}/${repoName}/issues?state=all`, {
-            auth: {
-                username: process.env.GITHUB_USER,
-                password: process.env.GITHUB_PASS
-            }
+            Authorization: auth
         })
             .then(function (response) {
                 resolve(response.data);
@@ -42,10 +37,7 @@ function issueDetails(githubUser, repoName, issueNum) {
 
     return new Promise((resolve, reject) => {
         axios.get(`https://api.github.com/repos/${githubUser}/${repoName}/issues/${issueNum}`, {
-            auth: {
-                username: process.env.GITHUB_USER,
-                password: process.env.GITHUB_PASS
-            }
+            Authorization: auth
         })
             .then(function (response) {
                 resolve(response.data);


### PR DESCRIPTION
I think GitHub may have changed to prevent username/password from being sent on authorization. I changed to send the token, instead.

Error message from previous attempts:
data: {
      message: "Bad credentials. The API can't be accessed using username/password authentication. Please create a personal access token to access this endpoint: http://github.com/settings/tokens",
      documentation_url: 'https://docs.github.com/articles/creating-a-personal-access-token-for-the-command-line'
    }